### PR TITLE
chore: adds commit-analyzer to release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,15 @@
 {
   "plugins": [
+    "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/git", {
-      "assets": ["package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }]
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "package.json"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
To help troubleshooting, by getting us to parity with the docs we're following: https://github.com/semantic-release/git (though i'm not sure why commit-analyzer is included there).