### PR TITLE
chore: add npm to release plugin list

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
This adds npm to the plugin list since apparently it overrides instead of merges (see https://github.com/semantic-release/semantic-release/blob/master/docs/usage/plugins.md#plugins)